### PR TITLE
Use Create instead of Open

### DIFF
--- a/netdef/main.go
+++ b/netdef/main.go
@@ -25,7 +25,7 @@ func readConfig(path string) (*netdef.Config, error) {
 }
 
 func writeRender(path string, r *netdef.RenderedNetwork) error {
-	fi, err := os.Open(path)
+	fi, err := os.Create(path)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Use `Create()` to get a file handle with `O_RDWR` instead of `Open()` which
only provides `O_RDONLY`.