### PR TITLE
Use DigitalOcean's OVS library

### DIFF
--- a/netdef/main.go
+++ b/netdef/main.go
@@ -85,7 +85,8 @@ func main() {
 			}
 			defer fi.Close()
 
-			var r netdef.RenderedNetwork
+			cfg := netdef.Config{}
+			r := cfg.NewRenderedNetwork()
 			if err := json.NewDecoder(fi).Decode(&r); err != nil {
 				return err
 			}


### PR DESCRIPTION
Use DigitalOcean's OVS library with the hope that they'll eventually switch away from shelling out to `ovs-vsctl`.